### PR TITLE
cleanups

### DIFF
--- a/g_ctffunc.c
+++ b/g_ctffunc.c
@@ -456,6 +456,9 @@ qboolean ctf_spawnflag(int teamnum)
 		//ent->s.effects |= EF_COLOR_SHELL | EF_FLAG1;
 		//ent->s.renderfx |= RF_SHELL_RED;
 		ent->s.effects = EF_FLAG1;
+		// Paril
+		ent->s.frame = 173;
+		// Paril
 		redflag = ent;
 	}
 	else if (teamnum == CTF_TEAM_BLUE && !blueflag) // BLUE FLAG
@@ -499,6 +502,9 @@ qboolean ctf_spawnflag(int teamnum)
 		//ent->s.effects |= EF_COLOR_SHELL | EF_FLAG2;
 		//ent->s.renderfx |= RF_SHELL_BLUE;
 		ent->s.effects = EF_FLAG2;
+		// Paril
+		ent->s.frame = 173;
+		// Paril
 		blueflag = ent;
 	}
 

--- a/g_main.c
+++ b/g_main.c
@@ -700,7 +700,14 @@ void G_RunFrame (void)
 	// CTF CODE -- LM_JORM
 	int			score;
 	edict_t		*cl_ent;
-		
+
+	// Paril
+	if (GamePaused())
+	{
+		ClientEndServerFrames();
+		return;
+	}
+	// Paril
 
 	bluescore = 0; 
 	redscore = 0;  
@@ -779,7 +786,6 @@ void G_RunFrame (void)
 
 		G_RunEntity (ent);
 	}
-
 
 	// see if it is time to end a deathmatch
 	CheckDMRules ();

--- a/g_menu.c
+++ b/g_menu.c
@@ -9,7 +9,7 @@
 void Cmd_Team_f (edict_t *ent);
 void Team_Change(edict_t *ent, int newnum);
 void ChaseCam (edict_t *ent);
-void Menu_Blank ();
+void Menu_Blank (edict_t *ent);
 void Observe (edict_t *ent);
 void f(edict_t *ent);
 void Show_String(int x, int y, char *string, char *Text);
@@ -251,8 +251,7 @@ void Ctf_Menu (edict_t *ent)
 	if (cl->showmenu)
 	{
 		cl->showmenu = false;
-		Menu_Blank();
-		gi.unicast (ent, true);
+		Menu_Blank(ent);
 		return;
 	}
 
@@ -301,7 +300,6 @@ void Main_Menu (edict_t *ent)
 	cl->menuselect = 0;
 		
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 void Skin_Old_Menu (edict_t *ent)
@@ -315,7 +313,6 @@ void Skin_Old_Menu (edict_t *ent)
 
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 
@@ -399,7 +396,6 @@ void Skin_Menu (edict_t *ent)
 	Menu_Set(ent, 17, "<next page>", Skin_Menu);
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 
@@ -412,8 +408,7 @@ void Observe (edict_t *ent)
 		Drop_All(ent);
 		ctf_SetEntTeam(ent, CTF_TEAM_OBSERVER);
 		ent->client->showmenu = false;
-		Menu_Blank();
-		gi.unicast (ent, true);
+		Menu_Blank(ent);
 		Observer_Start(ent);
 	}
 	else
@@ -421,8 +416,7 @@ void Observe (edict_t *ent)
 		Drop_All(ent);
 		TeamJoin (ent);
 		ent->client->showmenu = false;
-		Menu_Blank();
-		gi.unicast (ent, true);
+		Menu_Blank(ent);
 		Observer_Stop(ent);
 	}
 }
@@ -518,7 +512,6 @@ void Help_Menu (edict_t *ent)
 	cl->menuselect = 1;
 	
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 */
 
@@ -532,7 +525,6 @@ void HowToPlay_Menu (edict_t *ent)
 	cl->menuselect = 1;
 	
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 /*
@@ -551,7 +543,6 @@ void Command_Menu (edict_t *ent)
 		cl->menuselect = (cl->menuselect + 1) % menulist[cl->menu].size;
 	
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 */
 
@@ -571,8 +562,7 @@ void Toggle_Radio_Menu (edict_t *ent)
 	if (cl->showmenu)
 	{
 		cl->showmenu = false;
-		Menu_Blank();
-		gi.unicast (ent, true);
+		Menu_Blank(ent);
 		return;
 	}
 
@@ -590,7 +580,6 @@ void Radio_Menu (edict_t *ent)
 	cl->menuselect = 1;
 	
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 void PickSound (edict_t *ent)
@@ -598,8 +587,7 @@ void PickSound (edict_t *ent)
 	PlayTeamSound(ent, radiosound[ent->client->menuselect]);
 
 	ent->client->showmenu = false;
-	Menu_Blank();
-	gi.unicast (ent, true);
+	Menu_Blank(ent);
 	return;
 }
 
@@ -635,7 +623,6 @@ void Obs_Main_Menu (edict_t *ent)
 	Menu_Set(ent, 10, "Help", Help_Menu);
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 
 }
 #else //bat
@@ -664,7 +651,6 @@ char text[MAX_INFO_STRING];
 	Menu_Set(ent, 10, "Help", Help_Menu);
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 #endif
 
@@ -684,8 +670,7 @@ void Ref_Main_Load (edict_t *ent)
 	if (cl->showmenu)
 	{
 		cl->showmenu = false;
-		Menu_Blank();
-		gi.unicast (ent, true);
+		Menu_Blank(ent);
 		return;
 	}
 
@@ -731,7 +716,6 @@ void Ref_Main_Menu (edict_t *ent)
 		Menu_Set(ent, 13, "Save Config (RCON)", SaveServer_Exec);
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 void RefTogglePause(edict_t *ent)
@@ -924,7 +908,6 @@ void Ref_Help_Menu(edict_t *ent)
 	Menu_Set(ent, 17, "<next page>", Ref_Help_Menu);
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 
@@ -948,7 +931,6 @@ void Ref_Practice_Menu(edict_t *ent)
 		sprintf(text, "Blue Flag:    %s", "NORMAL");
 	Menu_Set(ent, 4, text, Ref_PracticeFlagBlue_Exec);
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 void Ref_PracticeFlagRed_Exec(edict_t *ent)
@@ -1010,7 +992,6 @@ void Ref_PingFloor_Menu (edict_t *ent)
 	}
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 void PingFloor_Exec (edict_t *ent)
@@ -1038,7 +1019,6 @@ void Ref_PingCeiling_Menu (edict_t *ent)
 	}
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 void PingCeiling_Exec (edict_t *ent)
@@ -1073,7 +1053,6 @@ void Ref_Settings_Menu (edict_t *ent)
 	
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 void ClearPassword_Exec (edict_t *ent)
@@ -1141,7 +1120,6 @@ void Ref_DMFlags_Menu (edict_t *ent)
 	Menu_Set(ent, 17, text, DMFlags_Exec);
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 void CTFFlags_Exec (edict_t *ent)
@@ -1206,7 +1184,6 @@ void Ref_CTFFlags_Menu (edict_t *ent)
 	
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 int timeslist[] = 
@@ -1256,7 +1233,6 @@ void Ref_Timelimit_Menu (edict_t *ent)
 	}
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 int fragslist[] = 
@@ -1306,7 +1282,6 @@ void Ref_Fraglimit_Menu (edict_t *ent)
 	}
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 
@@ -1484,7 +1459,6 @@ void Ref_Match_Maplist_Menu (edict_t *ent)
 	Menu_Set(ent, 17, "<next page>", Ref_Match_Maplist_Menu);
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 void Ref_Map_Maplist_Menu (edict_t *ent)
@@ -1522,7 +1496,6 @@ void Ref_Map_Maplist_Menu (edict_t *ent)
 	Menu_Set(ent, 17, "<next page>", Ref_Map_Maplist_Menu);
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 
@@ -1547,7 +1520,6 @@ void Ref_Match_A_Menu (edict_t *ent)
 	}
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 void Ref_Map_A_Menu (edict_t *ent)
@@ -1571,7 +1543,6 @@ void Ref_Map_A_Menu (edict_t *ent)
 	}
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 void Ref_Match_B_Menu (edict_t *ent)
@@ -1595,7 +1566,6 @@ void Ref_Match_B_Menu (edict_t *ent)
 	}
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 
@@ -1620,7 +1590,6 @@ void Ref_Match_C_Menu (edict_t *ent)
 	}
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 
@@ -1645,7 +1614,6 @@ void Ref_Map_B_Menu (edict_t *ent)
 	}
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 
@@ -1670,7 +1638,6 @@ void Ref_Map_C_Menu (edict_t *ent)
 	}
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 
@@ -1696,7 +1663,6 @@ void Ref_Match_Menu (edict_t *ent)
 	if (maplistindex != -2) // No list
 		Menu_Set(ent, 5, "Maplist", Ref_Match_Maplist_Menu);
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 void Ref_Map_Menu (edict_t *ent)
@@ -1715,7 +1681,6 @@ void Ref_Map_Menu (edict_t *ent)
 		Menu_Set(ent, 5, "Maplist", Ref_Map_Maplist_Menu);
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 
@@ -1757,7 +1722,6 @@ void Ref_Kick_Menu (edict_t *ent)
 	}
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 
@@ -1800,15 +1764,13 @@ void Voice_Menu (edict_t *ent)
 	}
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 void Voice_Exec (edict_t *ent)
 {
 	PlayVoiceSound(ent, voicelist[ent->client->menuselect]);
 	ent->client->showmenu = false;
-	Menu_Blank();
-	gi.unicast (ent, true);
+	Menu_Blank(ent);
 }
 
 void Change_Team_Exec(edict_t *ent)
@@ -1861,7 +1823,6 @@ void Help_Menu (edict_t *ent)
 	Menu_Set(ent, 17, "<next page>", Help_Menu);
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 
@@ -1906,10 +1867,11 @@ void Menu_Draw (edict_t *ent)
 	int selected;
 
 	// Keep from updating the menu more than once per frame
-	if (ent->client->menumovetime == level.framenum)
+	// Paril: unless we're paused, in which case...
+	if (ent->client->menumovetime == level.framenum && !GamePaused())
 		return;
-	else
-		ent->client->menumovetime = level.framenum;
+
+	ent->client->menumovetime = level.framenum;
 	
 	gi.WriteByte (svc_layout);
 	strcpy(string, "xv 32 yv 8 picn inventory ");
@@ -1955,13 +1917,18 @@ void Menu_Draw (edict_t *ent)
 	}
 
 	gi.WriteString (string);
-
+	// Paril
+	gi.unicast (ent, true);
+	// Paril
 }
 
-void Menu_Blank ()
+void Menu_Blank (edict_t *ent)
 {
 	gi.WriteByte (svc_layout);
 	gi.WriteString ("");
+	// Paril
+	gi.unicast (ent, true);
+	// Paril
 }
 
 
@@ -1989,7 +1956,6 @@ void Menu_Next (edict_t *ent)
 		cl->menuselect = (cl->menuselect + 1) % size;
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 void Menu_Prev (edict_t *ent)
@@ -2025,7 +1991,6 @@ void Menu_Prev (edict_t *ent)
 	}
 
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 
 void Menu_Use (edict_t *ent)
@@ -2064,5 +2029,4 @@ void Menu_Use (edict_t *ent)
 		}
 	}
 	//Menu_Draw (ent);
-	//gi.unicast (ent, true);
 }

--- a/g_vote.c
+++ b/g_vote.c
@@ -241,6 +241,5 @@ void Vote_Menu (edict_t *ent)             //Vampire -- voting menu
 	cl->menuselect = 0;
 		
 	Menu_Draw (ent);
-	gi.unicast (ent, true);
 }
 /* END -- Vampire */

--- a/p_client.c
+++ b/p_client.c
@@ -1766,7 +1766,7 @@ int i, numspec;
 		//I only want to do this shit if they have typed the spectator command!
 		if(ent->client->ctf.teamnum != CTF_TEAM_RED &&
 			ent->client->ctf.teamnum != CTF_TEAM_BLUE)
-		 		ent->client->ctf.New_Team = Team_To_Join(ent);
+	 		ent->client->ctf.New_Team = Team_To_Join(ent);
 
 		gi.bprintf (PRINT_HIGH, "%s joined the game\n", ent->client->pers.netname);
 	}
@@ -2846,6 +2846,9 @@ void ClientThink (edict_t *ent, usercmd_t *ucmd)
 	//bat not needed for team observers
 	//if(client->ctf.teamnum != CTF_TEAM_OBSERVER_RED &&
 	//	client->ctf.teamnum != CTF_TEAM_OBSERVER_BLUE)
+	// Paril
+	if (!GamePaused())
+	// Paril
 	{
 		if (client->latched_buttons & BUTTON_ATTACK)
 		{
@@ -2873,7 +2876,6 @@ void ClientThink (edict_t *ent, usercmd_t *ucmd)
 
 	if (client->resp.spectator) 
 	{
-		
 		if(client->ctf.teamnum == CTF_TEAM_OBSERVER_RED &&
 			!Team_Observer_OK(CTF_TEAM_RED, ent))
 		{

--- a/p_view.c
+++ b/p_view.c
@@ -980,125 +980,140 @@ void ClientEndServerFrame (edict_t *ent)
 
 	current_player = ent;
 	current_client = ent->client;
-
-	if (ent->client->hookstate) // We are still grappled
-	{
-		Weapon_Hook_Fire(ent);
-	}
-
-	//
-	// If the origin or velocity have changed since ClientThink(),
-	// update the pmove values.  This will happen when the client
-	// is pushed by a bmodel or kicked by an explosion.
-	// 
-	// If it wasn't updated here, the view position would lag a frame
-	// behind the body position when pushed -- "sinking into plats"
-	//
-	for (i=0 ; i<3 ; i++)
-	{
-		current_client->ps.pmove.origin[i] = ent->s.origin[i]*8.0;
-		current_client->ps.pmove.velocity[i] = ent->velocity[i]*8.0;
-	}
-
-	//
-	// If the end of unit layout is displayed, don't give
-	// the player any normal movement attributes
-	//
-	if (level.intermissiontime)
-	{
-		// FIXME: add view drifting here?
-		current_client->ps.blend[3] = 0;
-		current_client->ps.fov = 90;
-		G_SetStats (ent);
-		return;
-	}
-
-	AngleVectors (ent->client->v_angle, forward, right, up);
-
-	// burn from lava, etc
-	P_WorldEffects ();
-
-	//
-	// set model angles from view angles so other things in
-	// the world can tell which direction you are looking
-	//
-	if (ent->client->v_angle[PITCH] > 180)
-		ent->s.angles[PITCH] = (-360 + ent->client->v_angle[PITCH])/3;
-	else
-		ent->s.angles[PITCH] = ent->client->v_angle[PITCH]/3;
-	ent->s.angles[YAW] = ent->client->v_angle[YAW];
-	ent->s.angles[ROLL] = 0;
-	ent->s.angles[ROLL] = SV_CalcRoll (ent->s.angles, ent->velocity)*4;
-
-	//
-	// calculate speed and cycle to be used for
-	// all cyclic walking effects
-	//
-	xyspeed = sqrtf(ent->velocity[0]*ent->velocity[0] + ent->velocity[1]*ent->velocity[1]);
-
-	if (xyspeed < 5)
-	{
-		bobmove = 0;
-		current_client->bobtime = 0;	// start at beginning of cycle again
-	}
-	else if (ent->groundentity)
-	{	// so bobbing only cycles when on ground
-		if (xyspeed > 210)
-			bobmove = 0.25;
-		else if (xyspeed > 100)
-			bobmove = 0.125;
-		else
-			bobmove = 0.0625;
-	}
 	
-	bobtime = (current_client->bobtime += bobmove);
+	// Paril
+	if (!GamePaused())
+	{
+	// Paril
+		if (ent->client->hookstate) // We are still grappled
+		{
+			Weapon_Hook_Fire(ent);
+		}
 
-	if (current_client->ps.pmove.pm_flags & PMF_DUCKED)
-		bobtime *= 4;
+		//
+		// If the origin or velocity have changed since ClientThink(),
+		// update the pmove values.  This will happen when the client
+		// is pushed by a bmodel or kicked by an explosion.
+		// 
+		// If it wasn't updated here, the view position would lag a frame
+		// behind the body position when pushed -- "sinking into plats"
+		//
+		for (i=0 ; i<3 ; i++)
+		{
+			current_client->ps.pmove.origin[i] = ent->s.origin[i]*8.0;
+			current_client->ps.pmove.velocity[i] = ent->velocity[i]*8.0;
+		}
 
-	bobcycle = (int)bobtime;
-	bobfracsin = fabs(sin(bobtime*M_PI));
+		//
+		// If the end of unit layout is displayed, don't give
+		// the player any normal movement attributes
+		//
+		if (level.intermissiontime)
+		{
+			// FIXME: add view drifting here?
+			current_client->ps.blend[3] = 0;
+			current_client->ps.fov = 90;
+			G_SetStats (ent);
+			return;
+		}
 
-	// detect hitting the floor
-	P_FallingDamage (ent);
+		AngleVectors (ent->client->v_angle, forward, right, up);
 
-	// apply all the damage taken this frame
-	P_DamageFeedback (ent);
+		// burn from lava, etc
+		P_WorldEffects ();
 
-	// determine the view offsets
-	SV_CalcViewOffset (ent);
+		//
+		// set model angles from view angles so other things in
+		// the world can tell which direction you are looking
+		//
+		if (ent->client->v_angle[PITCH] > 180)
+			ent->s.angles[PITCH] = (-360 + ent->client->v_angle[PITCH])/3;
+		else
+			ent->s.angles[PITCH] = ent->client->v_angle[PITCH]/3;
+		ent->s.angles[YAW] = ent->client->v_angle[YAW];
+		ent->s.angles[ROLL] = 0;
+		ent->s.angles[ROLL] = SV_CalcRoll (ent->s.angles, ent->velocity)*4;
 
-	// determine the gun offsets
-	SV_CalcGunOffset (ent);
+		//
+		// calculate speed and cycle to be used for
+		// all cyclic walking effects
+		//
+		xyspeed = sqrtf(ent->velocity[0]*ent->velocity[0] + ent->velocity[1]*ent->velocity[1]);
 
-	// determine the full screen color blend
-	// must be after viewoffset, so eye contents can be
-	// accurately determined
-	// FIXME: with client prediction, the contents
-	// should be determined by the client
-	SV_CalcBlend (ent);
+		if (xyspeed < 5)
+		{
+			bobmove = 0;
+			current_client->bobtime = 0;	// start at beginning of cycle again
+		}
+		else if (ent->groundentity)
+		{	// so bobbing only cycles when on ground
+			if (xyspeed > 210)
+				bobmove = 0.25;
+			else if (xyspeed > 100)
+				bobmove = 0.125;
+			else
+				bobmove = 0.0625;
+		}
+	
+		bobtime = (current_client->bobtime += bobmove);
+
+		if (current_client->ps.pmove.pm_flags & PMF_DUCKED)
+			bobtime *= 4;
+
+		bobcycle = (int)bobtime;
+		bobfracsin = fabs(sin(bobtime*M_PI));
+
+		// detect hitting the floor
+		P_FallingDamage (ent);
+
+		// apply all the damage taken this frame
+		P_DamageFeedback (ent);
+
+		// determine the view offsets
+		SV_CalcViewOffset (ent);
+
+		// determine the gun offsets
+		SV_CalcGunOffset (ent);
+
+		// determine the full screen color blend
+		// must be after viewoffset, so eye contents can be
+		// accurately determined
+		// FIXME: with client prediction, the contents
+		// should be determined by the client
+		SV_CalcBlend (ent);
+	// Paril
+	}
+	// Paril
 
 	// chase cam stuff
 	if (ent->client->resp.spectator)
 		G_SetSpectatorStats(ent);
 	else
 		G_SetStats (ent);
+
 	G_CheckChaseStats(ent);
+	
+	// Paril
+	if (!GamePaused())
+	{
+	// Paril
+		G_SetClientEvent (ent);
 
-	G_SetClientEvent (ent);
+		G_SetClientEffects (ent);
 
-	G_SetClientEffects (ent);
+		G_SetClientSound (ent);
 
-	G_SetClientSound (ent);
+		G_SetClientFrame (ent);
 
-	G_SetClientFrame (ent);
+		VectorCopy (ent->velocity, ent->client->oldvelocity);
+		VectorCopy (ent->client->ps.viewangles, ent->client->oldviewangles);
 
-	VectorCopy (ent->velocity, ent->client->oldvelocity);
-	VectorCopy (ent->client->ps.viewangles, ent->client->oldviewangles);
-
-	// clear weapon kicks
-	VectorClear (ent->client->kick_origin);
-	VectorClear (ent->client->kick_angles);
+		// clear weapon kicks
+		VectorClear (ent->client->kick_origin);
+		VectorClear (ent->client->kick_angles);
+	// Paril
+	}
+	// Paril
 	
 	if (ent->client->showscores &&  deathmatch->value)
 	{
@@ -1125,10 +1140,14 @@ void ClientEndServerFrame (edict_t *ent)
 	}
 	else 
 		ClientShowID(ent, NULL); 
-
-	// END CTF CODE -- LM_CTF
-
-
+	
+	// Paril
+	if (GamePaused())
+	{
+		ent->s.sound = 0;
+	}
+	// Paril
+// END CTF CODE -- LM_CTF
 }
 
 


### PR DESCRIPTION
pause entire sim, except for HUD stuff
clean up menu stuff by putting unicast inside of menu draw funcs, so that it's impossible to write a 0 byte menu
referees always get menu rendered even if it's same frame
don't let refs fire weapon
also fix "running" flags on spawn