### PR TITLE
build GitRevisionInfo.h in Linux/MSYS2 builds

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -170,7 +170,7 @@ SHLIBLDFLAGS = -shared
 # Targets
 ######################################################################
 
-all: dep $(TARGET)
+all: GitRevisionInfo dep $(TARGET)
 
 GitRevisionInfo:
 	sed -e 's/\$$//g' GitRevisionInfo.tmpl | sed -e "s/WCLOGCOUNT+2/${REV}/g" | sed -e "s/WCREV=7/${VER}/g"  | sed -e "s/WCNOW=%Y/$(shell date +%Y)/g" > GitRevisionInfo.h
@@ -178,7 +178,7 @@ GitRevisionInfo:
 .c.o:
 	$(CC) $(CFLAGS) $(SHLIBCFLAGS) -o $@ -c $<
 
-$(TARGET):	$(OBJS) $(L_OBJS) GitRevisionInfo
+$(TARGET):	$(OBJS) $(L_OBJS)
 		$(CC) $(CFLAGS) $(SHLIBLDFLAGS) -o $@ $(OBJS) $(L_OBJS) $(LDFLAGS)
 		$(LIBTOOL) $@
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -172,10 +172,13 @@ SHLIBLDFLAGS = -shared
 
 all: dep $(TARGET)
 
+GitRevisionInfo:
+	sed -e 's/\$$//g' GitRevisionInfo.tmpl | sed -e "s/WCLOGCOUNT+2/${REV}/g" | sed -e "s/WCREV=7/${VER}/g"  | sed -e "s/WCNOW=%Y/$(shell date +%Y)/g" > GitRevisionInfo.h
+
 .c.o:
 	$(CC) $(CFLAGS) $(SHLIBCFLAGS) -o $@ -c $<
 
-$(TARGET):	$(OBJS) $(L_OBJS)
+$(TARGET):	$(OBJS) $(L_OBJS) GitRevisionInfo
 		$(CC) $(CFLAGS) $(SHLIBLDFLAGS) -o $@ $(OBJS) $(L_OBJS) $(LDFLAGS)
 		$(LIBTOOL) $@
 
@@ -193,7 +196,7 @@ stripcr:	.
 
 clean:
 		@echo "Deleting temporary files..."
-		@rm -f $(OBJS) *.orig ~* core
+		@rm -f $(OBJS) GitRevisionInfo.h *.orig ~* core
 
 distclean:	clean
 		@echo "Deleting everything that can be rebuilt..."

--- a/g_local.h
+++ b/g_local.h
@@ -45,9 +45,7 @@ _CrtMemState startup1;	// memory diagnostics
 
 #include "game.h"
 
-#if defined(_WIN32) && !(defined(__MINGW32__) || defined(__MINGW64__))
 #include "GitRevisionInfo.h" // Derived from template via GitWCRev
-#endif // _WIN32
 
 
 #define ISREF(ent) (ent->client->ctf.extra_flags & CTF_EXTRAFLAGS_REFEREE)

--- a/g_save.c
+++ b/g_save.c
@@ -6,7 +6,6 @@
 #include "g_skins.h"
 #include "g_ctffunc.h" //surt for log renaming
 #include "bat.h"
-#include "GitRevisionInfo.h"
 
 #define Function(f) {#f, f}
 


### PR DESCRIPTION
This lets the makefile build on Linux/WSL without issue and allows both Linux and MSVC builds to use `GitRevisionInfo.h`. I removed the include in g_save since it should already be included from g_local which I was able to make unconditional.