### PR TITLE
GNUmakefile fixes for MSYS & MinGW

### DIFF
--- a/g_local.h
+++ b/g_local.h
@@ -9,7 +9,7 @@
 #define _CRTDBG_MAP_ALLOC
 #include <stdlib.h>
 #include <crtdbg.h>
-_CrtMemState startup1;	// memory diagnostics
+extern _CrtMemState startup1;	// memory diagnostics
 #else
 #define OutputDebugString	//not doing Windows
 #endif

--- a/g_main.c
+++ b/g_main.c
@@ -7,6 +7,10 @@
 #include "gslog.h"	//	StdLog - Mark Davies
 #include "bat.h"
 
+#ifdef _WIN32
+_CrtMemState startup1;	// memory diagnostics
+#endif
+
 game_locals_t	game;
 level_locals_t	level;
 game_import_t	gi;

--- a/q_shared.c
+++ b/q_shared.c
@@ -6,7 +6,7 @@ vec3_t vec3_origin = {0,0,0};
 
 //============================================================================
 
-#ifdef _WIN32
+#if defined _WIN32 && defined _MSC_VER
 #pragma optimize( "", off )
 #endif
 
@@ -65,7 +65,7 @@ void RotatePointAroundVector( vec3_t dst, const vec3_t dir, const vec3_t point, 
 	}
 }
 
-#ifdef _WIN32
+#if defined _WIN32 && defined _MSC_VER
 #pragma optimize( "", on )
 #endif
 
@@ -229,7 +229,7 @@ void R_ConcatTransforms (float in1[3][4], float in2[3][4], float out[3][4])
 //============================================================================
 
 
-#if defined _M_IX86 && !defined C_ONLY
+#if defined _M_IX86 && defined _MSC_VER && !defined C_ONLY
 #pragma warning (disable:4035)
 __declspec( naked ) long Q_ftol( float f )
 {
@@ -313,7 +313,7 @@ BoxOnPlaneSide
 Returns 1, 2, or 1 + 2
 ==================
 */
-#if !id386 || defined __linux__ 
+#if !defined _M_IX86 || !defined _MSC_VER || defined C_ONLY
 int BoxOnPlaneSide (vec3_t emins, vec3_t emaxs, struct cplane_s *p)
 {
 	float	dist1, dist2;

--- a/q_shared.h
+++ b/q_shared.h
@@ -1,7 +1,7 @@
 	
 // q_shared.h -- included first by ALL program modules
 
-#if defined _WIN32 && !defined __CYGWIN__
+#if defined _WIN32 && defined _MSC_VER
 #pragma warning(disable : 4244)    // data conversions
 #pragma warning(disable : 4459)    // declaration of 'var' hides global declaration
 #pragma warning(disable : 4100)    //unreferenced formal parameter lots in id code
@@ -122,7 +122,7 @@ extern vec3_t vec3_origin;
 
 #define	IS_NAN(x) (((*(int *)&x)&nanmask)==nanmask)
 
-#if !defined C_ONLY && !defined __linux__ && !defined __sgi
+#if defined _M_IX86 && defined _MSC_VER && !defined C_ONLY
 extern long Q_ftol( float f );
 #else
 #define Q_ftol( f ) ( long ) (f)


### PR DESCRIPTION
The GNUmakefile had some token support for building an MSYS-native binary (though there's no reason to ever do that), but had some weirdness like building it as an `.so` instead of a `.dll`. It did not seem to have any support for building from the MSYS2 environments that target native Windows apps (i.e. directly use msvcrt/ucrt instead of `msys-2.0.dll`). I spruced up the makefile to support building native Windows dlls from MSYS2. I had to also make some minor source changes because some things guarded by _WIN32 are more MSVC-specific than Windows-specific and don't really work in GCC. I tested that the DLL produced by this in the MSYS2 MINGW32 environment is able to load and run with the original Quake II engine and seemed to be working as expected.

(Also snuck in a minor fix to allow to compile on Alpine Linux.)

The only thing I was very unsure about was `_CrtMemState startup1`. I'm not familiar with that struct or the Windows APIs you're using it with. MinGW very much did not like the symbol being defined in a header though and tried to put a separate copy of it into each object file so I marked that extern and just defined it in `g_main.c`. I didn't see any negative impact, but again I am not sure how to test the memory debugging stuff or how that works.